### PR TITLE
Rework exception handling

### DIFF
--- a/plugins/check_os_keystone.py
+++ b/plugins/check_os_keystone.py
@@ -100,7 +100,8 @@ def main():
                   " server: %s" % (keystone_host))
             sys.exit(2)
 
-    except Exception, ex:
+    except Exception as ex: # pylint: disable=broad-except
+        # All other exceptional conditions, we report as 'UNKNOWN' probe status
         print("UNKNOWN - Unexpected error while testing "
               "Keystone API: %s" % (str(ex)))
         sys.exit(3)


### PR DESCRIPTION
- Silence pylint about too broad exception, as this is the intended purpose
- Add a comment explaining just that
- Use the new form introduced in 2.6: "except Exc as exc_var_name"
  see : https://docs.python.org/3/whatsnew/2.6.html#pep-3110-exception-handling-changes