### PR TITLE
Handle argparse version handling

### DIFF
--- a/plugins/check_os_glance
+++ b/plugins/check_os_glance
@@ -103,8 +103,8 @@ def check_api(host, port, token):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Check Glance API.",
-                                     version="0.1")
+    parser = argparse.ArgumentParser(description="Check Glance API.")
+    parser.add_argument('--version', action='version', version='%(prog)s 0.1')
     parser.add_argument('config_file', metavar='CONFIG_FILE', type=str,
                         help=('Configuration file'))
     args = parser.parse_args()

--- a/plugins/check_os_keystone
+++ b/plugins/check_os_keystone
@@ -43,8 +43,8 @@ def get_os_params(config_file):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Check Keystone API.",
-                                     version="0.1")
+    parser = argparse.ArgumentParser(description="Check Keystone API.")
+    parser.add_argument('--version', action='version', version='%(prog)s 0.1')
     parser.add_argument('config_file', metavar='CONFIG_FILE', type=str,
                         help=('Configuration file'))
     args = parser.parse_args()


### PR DESCRIPTION
- Add "--version" CLI arg
- Remove version argument to ArgumentParser constructor
  (was: conversion from OptionParser leftover ?)

See https://docs.python.org/3/library/argparse.html#action

Detected-by: pylint
Signed-off-by: Vincent Legoll <vincent.legoll@gmail.com>